### PR TITLE
Fix Silk Touch behavior for Golden Egg and Add missing tags

### DIFF
--- a/src/main/resources/data/forge/tags/blocks/stripped_logs.json
+++ b/src/main/resources/data/forge/tags/blocks/stripped_logs.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "vintagedelight:stripped_magic_vine",
+    "vintagedelight:stripped_magic_vine_block"
+  ]
+}

--- a/src/main/resources/data/forge/tags/blocks/stripped_wood.json
+++ b/src/main/resources/data/forge/tags/blocks/stripped_wood.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "vintagedelight:stripped_magic_vine_block"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/seeds.json
+++ b/src/main/resources/data/forge/tags/items/seeds.json
@@ -1,0 +1,8 @@
+{
+  "replace": false,
+  "values": [
+    "vintagedelight:cucumber_seeds",
+    "vintagedelight:oat_seeds",
+    "vintagedelight:ghost_pepper_seeds"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/seeds/cucumber.json
+++ b/src/main/resources/data/forge/tags/items/seeds/cucumber.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "vintagedelight:cucumber_seeds"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/seeds/ghost_pepper.json
+++ b/src/main/resources/data/forge/tags/items/seeds/ghost_pepper.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "vintagedelight:ghost_pepper_seeds"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/seeds/oat.json
+++ b/src/main/resources/data/forge/tags/items/seeds/oat.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "vintagedelight:oat_seeds"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/stripped_logs.json
+++ b/src/main/resources/data/forge/tags/items/stripped_logs.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "vintagedelight:stripped_magic_vine",
+    "vintagedelight:stripped_magic_vine_block"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/stripped_wood.json
+++ b/src/main/resources/data/forge/tags/items/stripped_wood.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "vintagedelight:stripped_magic_vine_block"
+  ]
+}

--- a/src/main/resources/data/minecraft/tags/items/logs.json
+++ b/src/main/resources/data/minecraft/tags/items/logs.json
@@ -1,0 +1,9 @@
+{
+  "replace": false,
+  "values": [
+    "vintagedelight:magic_vine",
+    "vintagedelight:magic_vine_block",
+    "vintagedelight:stripped_magic_vine",
+    "vintagedelight:stripped_magic_vine_block"
+  ]
+}

--- a/src/main/resources/data/minecraft/tags/items/planks.json
+++ b/src/main/resources/data/minecraft/tags/items/planks.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "vintagedelight:vine_tile"
+  ]
+}

--- a/src/main/resources/data/minecraft/tags/items/slabs.json
+++ b/src/main/resources/data/minecraft/tags/items/slabs.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "vintagedelight:vine_tile_slab"
+  ]
+}

--- a/src/main/resources/data/minecraft/tags/items/stairs.json
+++ b/src/main/resources/data/minecraft/tags/items/stairs.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "vintagedelight:vine_tile_stairs"
+  ]
+}

--- a/src/main/resources/data/minecraft/tags/items/walls.json
+++ b/src/main/resources/data/minecraft/tags/items/walls.json
@@ -1,0 +1,6 @@
+{
+  "values": [
+    "vintagedelight:salt_brick_wall",
+    "vintagedelight:mixed_salt_brick_wall"
+  ]
+}

--- a/src/main/resources/data/minecraft/tags/items/wooden_slabs.json
+++ b/src/main/resources/data/minecraft/tags/items/wooden_slabs.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "vintagedelight:vine_tile_slab"
+  ]
+}

--- a/src/main/resources/data/minecraft/tags/items/wooden_stairs.json
+++ b/src/main/resources/data/minecraft/tags/items/wooden_stairs.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "vintagedelight:vine_tile_stairs"
+  ]
+}

--- a/src/main/resources/data/vintagedelight/loot_tables/blocks/golden_egg.json
+++ b/src/main/resources/data/vintagedelight/loot_tables/blocks/golden_egg.json
@@ -3,51 +3,52 @@
   "pools": [
     {
       "rolls": 1.0,
+      "conditions": [
+        {
+          "condition": "minecraft:match_tool",
+          "predicate": {
+            "enchantments": [
+              {
+                "enchantment": "minecraft:silk_touch",
+                "levels": {
+                  "min": 1
+                }
+              }
+            ]
+          }
+        }
+      ],
       "entries": [
         {
           "type": "minecraft:item",
-          "conditions": [
-            {
-              "condition": "minecraft:match_tool",
-              "predicate": {
-                "enchantments": [
-                  {
-                    "enchantment": "minecraft:silk_touch",
-                    "levels": {
-                      "min": 1
-                    }
-                  }
-                ]
-              }
-            }
-          ],
           "name": "vintagedelight:golden_egg"
         }
       ]
     },
+
     {
       "rolls": 1.0,
+      "conditions": [
+        {
+          "condition": "minecraft:inverted",
+          "term": {
+            "condition": "minecraft:match_tool",
+            "predicate": {
+              "enchantments": [
+                {
+                  "enchantment": "minecraft:silk_touch",
+                  "levels": {
+                    "min": 1
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ],
       "entries": [
         {
           "type": "minecraft:item",
-          "conditions": [
-            {
-              "condition": "minecraft:inverted",
-              "term": {
-                "condition": "minecraft:match_tool",
-                "predicate": {
-                  "enchantments": [
-                    {
-                      "enchantment": "minecraft:silk_touch",
-                      "levels": {
-                        "min": 1
-                      }
-                    }
-                  ]
-                }
-              }
-            }
-          ],
           "functions": [
             {
               "function": "minecraft:set_count",
@@ -73,36 +74,37 @@
         }
       ]
     },
+
     {
       "rolls": 1.0,
+      "conditions": [
+        {
+          "condition": "minecraft:inverted",
+          "term": {
+            "condition": "minecraft:match_tool",
+            "predicate": {
+              "enchantments": [
+                {
+                  "enchantment": "minecraft:silk_touch",
+                  "levels": {
+                    "min": 1
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ],
       "entries": [
         {
           "type": "minecraft:item",
-          "conditions": [
-            {
-              "condition": "minecraft:inverted",
-              "term": {
-                "condition": "minecraft:match_tool",
-                "predicate": {
-                  "enchantments": [
-                    {
-                      "enchantment": "minecraft:silk_touch",
-                      "levels": {
-                        "min": 1
-                      }
-                    }
-                  ]
-                }
-              }
-            }
-          ],
           "functions": [
             {
               "function": "minecraft:set_count",
               "count": {
                 "type": "minecraft:uniform",
                 "min": 1.0,
-                "max": 3.0
+                "max": 15.0
               }
             }
           ],
@@ -110,36 +112,37 @@
         }
       ]
     },
+
     {
       "rolls": 1.0,
+      "conditions": [
+        {
+          "condition": "minecraft:inverted",
+          "term": {
+            "condition": "minecraft:match_tool",
+            "predicate": {
+              "enchantments": [
+                {
+                  "enchantment": "minecraft:silk_touch",
+                  "levels": {
+                    "min": 1
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ],
       "entries": [
         {
           "type": "minecraft:item",
-          "conditions": [
-            {
-              "condition": "minecraft:inverted",
-              "term": {
-                "condition": "minecraft:match_tool",
-                "predicate": {
-                  "enchantments": [
-                    {
-                      "enchantment": "minecraft:silk_touch",
-                      "levels": {
-                        "min": 1
-                      }
-                    }
-                  ]
-                }
-              }
-            }
-          ],
           "functions": [
             {
               "function": "minecraft:set_count",
               "count": {
                 "type": "minecraft:uniform",
                 "min": 0.0,
-                "max": 2.0
+                "max": 7.0
               }
             }
           ],
@@ -147,36 +150,37 @@
         }
       ]
     },
+
     {
       "rolls": 1.0,
+      "conditions": [
+        {
+          "condition": "minecraft:inverted",
+          "term": {
+            "condition": "minecraft:match_tool",
+            "predicate": {
+              "enchantments": [
+                {
+                  "enchantment": "minecraft:silk_touch",
+                  "levels": {
+                    "min": 1
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ],
       "entries": [
         {
           "type": "minecraft:item",
-          "conditions": [
-            {
-              "condition": "minecraft:inverted",
-              "term": {
-                "condition": "minecraft:match_tool",
-                "predicate": {
-                  "enchantments": [
-                    {
-                      "enchantment": "minecraft:silk_touch",
-                      "levels": {
-                        "min": 1
-                      }
-                    }
-                  ]
-                }
-              }
-            }
-          ],
           "functions": [
             {
               "function": "minecraft:set_count",
               "count": {
                 "type": "minecraft:uniform",
                 "min": 2.0,
-                "max": 8.0
+                "max": 16.0
               }
             }
           ],

--- a/src/main/resources/data/vintagedelight/loot_tables/blocks/golden_egg.json
+++ b/src/main/resources/data/vintagedelight/loot_tables/blocks/golden_egg.json
@@ -104,7 +104,7 @@
               "count": {
                 "type": "minecraft:uniform",
                 "min": 1.0,
-                "max": 15.0
+                "max": 3.0
               }
             }
           ],
@@ -142,7 +142,7 @@
               "count": {
                 "type": "minecraft:uniform",
                 "min": 0.0,
-                "max": 7.0
+                "max": 2.0
               }
             }
           ],
@@ -180,7 +180,7 @@
               "count": {
                 "type": "minecraft:uniform",
                 "min": 2.0,
-                "max": 16.0
+                "max": 8.0
               }
             }
           ],


### PR DESCRIPTION
When mined with Silk Touch, the Golden Egg now only drops itself instead of additional loot. Additionally, missing tags have been added for Magic Vine, all seeds, and walls.